### PR TITLE
Reject unsupported mediatypes in coffee image endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -44,7 +44,7 @@ async def update_coffee_image(file: UploadFile, key: str = Security(api_key_head
     if not file.content_type in ACCEPTED_FILE_TYPES:
         return Response(
             content=f"Bad content type. Accepted types are: {ACCEPTED_FILE_TYPES}",
-            status_code=status.HTTP_400_BAD_REQUEST,
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
         )
     extension = file.content_type.split("/")[-1]
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -47,6 +47,13 @@ class TestKattilaApi(unittest.TestCase):
         response = self.client.put("/coffee/image", headers=headers, files=files)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
+    def test_coffee_image_endpoint_incorrect_media_type(self):
+        img = Image.new("RGB", (600, 800), color="white")
+        headers = {"X-API-Key": "TESTING_API_KEY"}
+        files = {"file": ("filename", img.tobytes(), "image/example")}
+        response = self.client.put("/coffee/image", headers=headers, files=files)
+        self.assertEqual(response.status_code, status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Uses an example mediatype from https://www.rfc-editor.org/rfc/rfc4735.html
This does not yet test accepting accepted media types