### PR TITLE
Refactor initializations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi[standard]
 aiofiles
+watchfiles


### PR DESCRIPTION
## What?
Refactored directory and api-key initialization at `app/main.py`.

## Why?
I assume we might introduce new folder structures later and even multiple api-keys.

## How?
Created `init_dir` and `init_api_key` functions that return the created folder, api key header and api key.

## Testing?
I was glad to see that all tests worked fine after changes.

## Anything Else?
I also added Doxygen [style](https://www.doxygen.nl/manual/docblocks.html) comments to the added code and think we could start using [Doxygen](https://www.doxygen.nl/index.html) on top of FAST-API docs for faster on-boarding of new developers. Maybe even in other Linkki projects.

I am happy to hear any complaints or suggestions regarding the PR if it does not align with your style or needs.